### PR TITLE
chore: add Prettier config and reformat codebase

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,10 @@
+# Ignore artifacts:
+build
+coverage
+android/app/
+vendor/
+ios/
+android/
+.github/workflows/test.yml
+*.json
+*.md

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,15 @@
+{
+    "tabWidth": 4,
+    "useTabs": false,
+    "semi": true,
+    "singleQuote": true,
+    "printWidth": 100,
+    "overrides": [
+        {
+            "files": ["*.json", "*.config.js", "*.config.ts"],
+            "options": {
+                "tabWidth": 2
+            }
+        }
+    ]
+}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,5 @@
-import { Stack } from "expo-router";
+import { Stack } from 'expo-router';
 
 export default function RootLayout() {
-  return <Stack />;
+    return <Stack />;
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,15 +1,15 @@
-import { Text, View } from "react-native";
+import { Text, View } from 'react-native';
 
 export default function Index() {
-  return (
-    <View
-      style={{
-        flex: 1,
-        justifyContent: "center",
-        alignItems: "center",
-      }}
-    >
-      <Text>Edit app/index.tsx to edit this screen.</Text>
-    </View>
-  );
+    return (
+        <View
+            style={{
+                flex: 1,
+                justifyContent: 'center',
+                alignItems: 'center',
+            }}
+        >
+            <Text>Edit app/index.tsx to edit this screen.</Text>
+        </View>
+    );
 }


### PR DESCRIPTION
Added `.prettierrc` and `.prettierignore` files to configure code formatting. Reformatted `app/_layout.tsx` and `app/index.tsx` to use single quotes, 4-space indentation, and other Prettier rules for consistency.