### PR TITLE
Remove refresh token deletion on unauthorized access

### DIFF
--- a/api/api.ts
+++ b/api/api.ts
@@ -19,7 +19,6 @@ api.interceptors.response.use(
             // Handle unauthorized responses
             console.error('Unauthorized access - perhaps you need to log in?');
             await SecureStore.deleteItemAsync('accessToken'); // Clear token
-            await SecureStore.deleteItemAsync('refreshToken'); // Clear refresh token
             return Promise.reject(new Error('Unauthorized'));
         }
         // Handle successful responses

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components';
 import { FontAwesome } from '@expo/vector-icons';
 import { AxiosResponse } from 'axios';
 import * as LocalAuthentication from 'expo-local-authentication';
-import { useFocusEffect, useRouter } from 'expo-router';
+import { useRouter } from 'expo-router';
 import * as SecureStore from 'expo-secure-store';
 import React, { useCallback, useState } from 'react';
 import {
@@ -24,7 +24,6 @@ export default function Login() {
     const router = useRouter();
     const colorScheme = useColorScheme();
     const [loading, setLoading] = useState(false);
-    const [showForm, setShowForm] = useState(false);
 
     const biometricVerification = useCallback(() => {
         (async () => {
@@ -33,7 +32,6 @@ export default function Login() {
                 const storedRefreshToken = await SecureStore.getItemAsync('refreshToken');
                 console.log('Stored refresh token:', storedRefreshToken);
                 if (!storedRefreshToken) {
-                    setShowForm(true);
                     setLoading(false);
                     return;
                 }
@@ -43,7 +41,6 @@ export default function Login() {
                 });
                 console.log('Biometric result:', biometricResult);
                 if (!biometricResult.success) {
-                    setShowForm(true);
                     setLoading(false);
                     return;
                 }
@@ -54,7 +51,6 @@ export default function Login() {
                 await SecureStore.setItemAsync('accessToken', response.data.access_token);
                 router.replace('/(restricted)/timer');
             } catch (err) {
-                setShowForm(true);
                 console.error(err);
                 await SecureStore.deleteItemAsync('accessToken');
                 await SecureStore.deleteItemAsync('refreshToken');

--- a/app/(restricted)/timer.tsx
+++ b/app/(restricted)/timer.tsx
@@ -1,6 +1,7 @@
 import { api } from '@/api';
 import { Button } from '@/components';
 import Dial from '@/components/Dial';
+import { AxiosError } from 'axios';
 import Constants from 'expo-constants';
 import * as Notifications from 'expo-notifications';
 import { useRouter } from 'expo-router';
@@ -28,9 +29,10 @@ export default function Timer() {
                 console.log('Push token registered successfully');
             } catch (error) {
                 console.error('Failed to register push token:', error);
-                await SecureStore.deleteItemAsync('accessToken');
-                await SecureStore.deleteItemAsync('refreshToken');
-                router.replace('/(auth)/login');
+                if (error instanceof AxiosError && error?.response?.status === 401) {
+                    await SecureStore.deleteItemAsync('accessToken');
+                    router.replace('/(auth)/login');
+                }
             }
         },
         [router],

--- a/providers/Connection.tsx
+++ b/providers/Connection.tsx
@@ -58,7 +58,6 @@ export const ConnectionProvider = ({ children }: { children: React.ReactNode }) 
 
             if (msg.code === 1008) {
                 await SecureStore.deleteItemAsync('accessToken');
-                await SecureStore.deleteItemAsync('refreshToken');
                 router.replace('/(auth)/login');
             }
         };


### PR DESCRIPTION
Updated logic to only delete the access token (not the refresh token) on unauthorised access or specific error cases in API, login, timer, and connection provider files. This change helps preserve the refresh token for potential re-authentication flows.